### PR TITLE
Fixing depends based auth

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -128,7 +128,6 @@ autoclass_content='both'
 # a list of builtin themes.
 
 # Required theme setup
-html_theme = 'sphinx_material'
 
 # Set link name generated in the top bar.
 html_title = 'FastAPI AAD Authentication'

--- a/src/fastapi_aad_auth/oauth/validators/token.py
+++ b/src/fastapi_aad_auth/oauth/validators/token.py
@@ -125,8 +125,12 @@ class TokenValidator(OAuth2AuthorizationCodeBearer):
     def _get_user_from_claims(self, claims):
         raise NotImplementedError('Implement in sub class')
 
-    async def __call__(self, request: Request) -> Optional[AuthenticationState]:
-        """Validate the request authentication"""
+    # TODO change pattern to better depend on alternate method
+    async def __call__(self, request: Request) -> AuthenticationState:  # type: ignore
+        """Validate the request authentication.
+        
+        Returns an AuthenticationState object or raises an Unauthorized eror
+        """
         result = self.check(request)
         logger.info(f'Identified state {result}')
         if not result.is_authenticated():

--- a/src/fastapi_aad_auth/oauth/validators/token.py
+++ b/src/fastapi_aad_auth/oauth/validators/token.py
@@ -10,8 +10,8 @@ from fastapi.security import OAuth2AuthorizationCodeBearer
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 import requests
-from starlette.requests import Request
 from starlette.middleware.authentication import AuthenticationError
+from starlette.requests import Request
 from starlette.status import HTTP_401_UNAUTHORIZED
 
 from fastapi_aad_auth.oauth.state import AuthenticationState, User
@@ -125,7 +125,8 @@ class TokenValidator(OAuth2AuthorizationCodeBearer):
     def _get_user_from_claims(self, claims):
         raise NotImplementedError('Implement in sub class')
 
-    async def __call__(self, request: Request) -> Optional[str]:
+    async def __call__(self, request: Request) -> Optional[AuthenticationState]:
+        """Validate the request authentication"""
         result = self.check(request)
         logger.info(f'Identified state {result}')
         if not result.is_authenticated():

--- a/src/fastapi_aad_auth/oauth/validators/token.py
+++ b/src/fastapi_aad_auth/oauth/validators/token.py
@@ -10,7 +10,9 @@ from fastapi.security import OAuth2AuthorizationCodeBearer
 from fastapi.security.utils import get_authorization_scheme_param
 from pydantic import BaseModel
 import requests
+from starlette.requests import Request
 from starlette.middleware.authentication import AuthenticationError
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 
 from fastapi_aad_auth.oauth.state import AuthenticationState, User
 
@@ -123,6 +125,17 @@ class TokenValidator(OAuth2AuthorizationCodeBearer):
     def _get_user_from_claims(self, claims):
         raise NotImplementedError('Implement in sub class')
 
+    async def __call__(self, request: Request) -> Optional[str]:
+        result = self.check(request)
+        logger.info(f'Identified state {result}')
+        if not result.is_authenticated():
+            raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Not authenticated",
+                headers={"WWW-Authenticate": "Bearer"},
+                )
+        return result
+
 
 class AADTokenValidator(TokenValidator):
     """Validator for AAD token based authentication."""
@@ -192,7 +205,7 @@ class AADTokenValidator(TokenValidator):
         if 'appid' in options and 'azp' in options:
             if 'appid' not in claims:
                 options.pop('appid')
-            if 'appid'not in claims:  # should this be an elif - i.e. we require it?
+            elif 'azp'not in claims:
                 options.pop('azp')
             if not ('appid' in claims or 'azp' in claims):
                 if self.strict:
@@ -214,4 +227,7 @@ class AADTokenValidator(TokenValidator):
 
     def _get_user_from_claims(self, claims):
         logger.debug(f'Processing claims: {claims}')
-        return self._user_klass(name=claims['name'], email=claims['preferred_username'], username=claims['preferred_username'], groups=claims.get('groups', []), roles=claims.get('roles', []))
+        username_key = 'preferred_username'
+        if username_key not in claims:
+            username_key = 'unique_name'
+        return self._user_klass(name=claims['name'], email=claims[username_key], username=claims[username_key], groups=claims.get('groups', []), roles=claims.get('roles', []))

--- a/src/fastapi_aad_auth/oauth/validators/token.py
+++ b/src/fastapi_aad_auth/oauth/validators/token.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 import requests
 from starlette.requests import Request
 from starlette.middleware.authentication import AuthenticationError
-from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
+from starlette.status import HTTP_401_UNAUTHORIZED
 
 from fastapi_aad_auth.oauth.state import AuthenticationState, User
 

--- a/src/fastapi_aad_auth/oauth/validators/token.py
+++ b/src/fastapi_aad_auth/oauth/validators/token.py
@@ -128,7 +128,7 @@ class TokenValidator(OAuth2AuthorizationCodeBearer):
     # TODO change pattern to better depend on alternate method
     async def __call__(self, request: Request) -> AuthenticationState:  # type: ignore
         """Validate the request authentication.
-        
+
         Returns an AuthenticationState object or raises an Unauthorized eror
         """
         result = self.check(request)


### PR DESCRIPTION
This should fix #16 - that was a refactoring oversight that dropped the auth check from depends (it wasn't raising an error) - it now returns an ``AuthenticationState`` object which contains a ``User`` - if it is not signed in, the ``__call__`` method raises a 401 Error, but for now it is not doing any further e.g. scope validation etc - this should be possible through the ``auth_required`` decorator, but may need confirming for auth paths

Additionally the returned state can be used for additional server side validation.

This was manually tested through the testapp, requests without auth gives a 401 error, with auth token (via SwaggerUI or requests) gives the expected 200 response on the testapp