### PR TITLE
Change User.roles and User.groups to optional

### DIFF
--- a/src/fastapi_aad_auth/oauth/state.py
+++ b/src/fastapi_aad_auth/oauth/state.py
@@ -29,8 +29,8 @@ class User(BaseModel):
     name: str
     email: str
     username: str
-    roles: List[str] = []
-    groups: List[str] = []
+    roles: Optional[List[str]] = None
+    groups: Optional[List[str]] = None
 
     @property
     def permissions(self):

--- a/src/fastapi_aad_auth/oauth/validators/token.py
+++ b/src/fastapi_aad_auth/oauth/validators/token.py
@@ -237,7 +237,7 @@ class AADTokenValidator(TokenValidator):
             username_key = 'unique_name'
         if 'name' not in claims and 'appid' in claims:
             # This is an application/service principal
-            return self._user_klass(name=claims['appid'], email='', username=claims['appid'], groups=claims.get('groups', []), roles=claims.get('roles', []))
+            return self._user_klass(name=claims['appid'], email='', username=claims['appid'], groups=claims.get('groups', None), roles=claims.get('roles', None))
 
         else:
-            return self._user_klass(name=claims['name'], email=claims[username_key], username=claims[username_key], groups=claims.get('groups', []), roles=claims.get('roles', []))
+            return self._user_klass(name=claims['name'], email=claims[username_key], username=claims[username_key], groups=claims.get('groups', None), roles=claims.get('roles', None))


### PR DESCRIPTION
- Change User.roles and User.groups to be optional and default to None

Reasoning: When instantiating the user class, and if the user class is defined by the app, it's better to use None as the default value instead of List. The User model defined by the app might be a database (ORM) model, that doesn't support Lists as types. Some preprocessing might be needed to convert the list to a string or similar.

- Use None as default value for roles and groups when instantiating the User class