### PR TITLE
Updating templates to use module based pathing for easier inheritance

### DIFF
--- a/src/fastapi_aad_auth/auth.py
+++ b/src/fastapi_aad_auth/auth.py
@@ -50,6 +50,10 @@ class Authenticator(LoggingMixin):
             context = self.config.login_ui.context.copy()
             context.update(base_context)
             base_context = context
+        if 'app_name' not in base_context:
+            base_context['app_name'] = self.config.login_ui.app_name
+        if 'static_path' not in base_context:
+            base_context['static_path'] = self.config.login_ui.static_path
         self._base_context = base_context
         self._add_to_base_routes = add_to_base_routes
         self._session_validator = self._init_session_validator()

--- a/src/fastapi_aad_auth/ui/__init__.py
+++ b/src/fastapi_aad_auth/ui/__init__.py
@@ -47,10 +47,10 @@ class UI(LoggingMixin):
 
     def _login(self, request: Request, *args, **kwargs):
         """Provide the Login UI."""
+        if not self.config.enabled or self._authenticator.auth_backend.is_authenticated(request):
+            return RedirectResponse(self.config.routing.home_path)
         context = self._base_context.copy()
         context.update(kwargs)  # type: ignore
-        if 'app_name' not in context:
-            context['app_name'] = self.config.login_ui.app_name
         if not self.config.enabled or request.user.is_authenticated:
             # This is authenticated so go straight to the homepage
             return RedirectResponse(self.config.routing.home_path)
@@ -62,10 +62,10 @@ class UI(LoggingMixin):
 
     def _get_user(self, request: Request, **kwargs):
         """Provide a UI with information on the user."""
+        if not self.config.enabled:
+            return RedirectResponse(self.config.routing.home_path)
         context = self._base_context.copy()  # type: ignore
         context.update(kwargs)
-        if 'app_name' not in context:
-            context['app_name'] = self.config.login_ui.app_name
         self.logger.debug(f'Getting token for {request.user}')
         context['request'] = request  # type: ignore
         context['token_api_path'] = f'{self.config.routing.user_path}/token'
@@ -78,7 +78,7 @@ class UI(LoggingMixin):
                 return self.__force_authenticate(request)
         else:
             self.logger.debug('Auth not enabled')
-            context['token'] = None  # type: ignore
+            context['token_api_path'] = None  # type: ignore
         return self.user_templates.TemplateResponse(self.user_template_path.name, context)
 
     def _get_token(self, request: Request, auth_state: AuthenticationState):

--- a/src/fastapi_aad_auth/ui/error.html
+++ b/src/fastapi_aad_auth/ui/error.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "fastapi_aad_auth.ui:base.html" %}
 {% block Content %}
         <main class='container' role="main">
             {% if logo %}

--- a/src/fastapi_aad_auth/ui/error.html
+++ b/src/fastapi_aad_auth/ui/error.html
@@ -28,4 +28,4 @@
             {% endif %}
         
         </main>
-{% block Content %}
+{% endblock Content %}

--- a/src/fastapi_aad_auth/ui/login.html
+++ b/src/fastapi_aad_auth/ui/login.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "fastapi_aad_auth.ui:base.html" %}
 {% block Content %}
         <div class='container'>
             <div class="cover-container d-flex h-100 p-3 mx-auto flex-column text-center justify-content-center">

--- a/src/fastapi_aad_auth/ui/user.html
+++ b/src/fastapi_aad_auth/ui/user.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "fastapi_aad_auth.ui:base.html" %}
 
 {% block CSS %}
         {{ super() }}


### PR DESCRIPTION
In the changes in #33 the templates were using folder based inheritance, which would fail when using elsewhere. This sets it to the pkg_resources based templating, which can be used elsewhere.