### PR TITLE
redirect https via load balancer

### DIFF
--- a/src/fastapi_aad_auth/providers/aad.py
+++ b/src/fastapi_aad_auth/providers/aad.py
@@ -85,7 +85,11 @@ class AADSessionAuthenticator(SessionAuthenticator):
                 port = ''
             else:
                 port = f':{request.url.port}'
-            redirect_uri = f'{request.url.scheme}://{request.url.hostname}{port}{self._redirect_path}'
+            if 'X-Forwarded-Proto' in request.headers and request.headers['X-Forwarded-Proto'] == 'https':
+                url_scheme='https'
+            else:
+                url_scheme='http'
+            redirect_uri = f'{url_scheme}://{request.url.hostname}{port}{self._redirect_path}'
         self.logger.info(f'Created redirect uri: {redirect_uri} from {request.url}')
         return redirect_uri
 

--- a/src/fastapi_aad_auth/providers/aad.py
+++ b/src/fastapi_aad_auth/providers/aad.py
@@ -86,9 +86,9 @@ class AADSessionAuthenticator(SessionAuthenticator):
             else:
                 port = f':{request.url.port}'
             if 'X-Forwarded-Proto' in request.headers and request.headers['X-Forwarded-Proto'] == 'https':
-                url_scheme='https'
+                url_scheme = 'https'
             else:
-                url_scheme='http'
+                url_scheme = 'http'
             redirect_uri = f'{url_scheme}://{request.url.hostname}{port}{self._redirect_path}'
         self.logger.info(f'Created redirect uri: {redirect_uri} from {request.url}')
         return redirect_uri


### PR DESCRIPTION
In App Service, SSL termination (wikipedia.org) happens at the network load balancers, so all HTTPS requests reach your app as unencrypted HTTP requests. If your app logic needs to check if the user requests are encrypted or not, inspect the X-Forwarded-Proto header.