### PR TITLE
Adding api_auth_required decorator

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -2,6 +2,20 @@ Using fastapi_aad_auth
 **********************
 Please see `Basic Usage <usage>`_ for information on how to configure and setup ``fastapi_aad_auth``.
 
+Customising authentication dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :meth:`~fastapi_aad_auth.auth.Authenticator.api_auth_required` method decorator provides controls over the scope, and is
+using the ``fastapi`` dependency injection system. If you want more customisation, you can use::
+
+    router = APIRouter()
+
+    @router.get('/hello')
+    async def hello_world(auth_state: AuthenticationState = Depends(auth_provider.auth_backend.requires_auth(allow_session=True))):
+        print(auth_state)
+        return {'hello': 'world'}
+
+
 Accessing User Tokens/View
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -112,7 +112,8 @@ You can use it for fastapi routes::
     router = APIRouter()
 
     @router.get('/hello')
-    async def hello_world(auth_state: AuthenticationState = Depends(auth_provider.auth_backend.requires_auth(allow_session=True))):
+    @auth_provider.api_auth_required(allow_session=True)
+    async def hello_world(auth_state: AuthenticationState):
         print(auth_state)
         return {'hello': 'world'}
 

--- a/src/fastapi_aad_auth/_base/state.py
+++ b/src/fastapi_aad_auth/_base/state.py
@@ -2,7 +2,7 @@
 from enum import Enum
 import importlib
 import json
-from typing import List, Optional
+from typing import List, Optional, Union
 import uuid
 
 from itsdangerous import URLSafeSerializer
@@ -164,3 +164,14 @@ class AuthenticationState(LoggingMixin, InheritableBaseModel):
     def as_unauthenticated(cls, serializer, session):
         """Store as an un-authenticated user."""
         return cls.authenticate_as(None, serializer, session)
+
+    def check_scopes(self, required_scopes: Optional[Union[List[str], str]] = None):
+        """Check if the user has the required scopes."""
+        if required_scopes is None:
+            return True
+        elif isinstance(required_scopes, str):
+            required_scopes = required_scopes.split(' ')
+        for scope in required_scopes:
+            if scope in self.credentials.scopes:
+                return True
+        return False

--- a/tests/testapp/server.py
+++ b/tests/testapp/server.py
@@ -21,6 +21,12 @@ async def hello_world(auth_state: AuthenticationState = Depends(auth_provider.au
     print(auth_state)
     return {'hello': 'world'}
 
+@router.get('/test_auth_decorator')
+@auth_provider.api_auth_required('authenticated', allow_session=False)
+async def hello_world2(auth_state: AuthenticationState, a: str = 'b'):
+    print(auth_state)
+    return {'hello': 'world', 'a': a}
+
 
 if 'untagged' in __version__ or 'unknown':
     API_VERSION = 0
@@ -38,7 +44,7 @@ async def homepage(request):
 async def test(request):
     if request.user.is_authenticated:
         return PlainTextResponse('Hello, ' + request.user.display_name)
- 
+
 routes = [
     Route("/", endpoint=homepage),
     Route("/test", endpoint=test)


### PR DESCRIPTION
implements the request for #64 to provide a method decorator rather than using the fastapi dependency injection.

Requires some signature tweaking for fastapi to parse into the openapi spec nicely.

Added an example in tests/testapp/server.py
```
@router.get('/test_auth_decorator')
@auth_provider.api_auth_required('authenticated', allow_session=False)
async def hello_world2(auth_state: AuthenticationState, a: str = 'b'):
    print(auth_state)
    return {'hello': 'world', 'a': a}
```
