### PR TITLE
Fix/74

### DIFF
--- a/src/fastapi_aad_auth/_base/backend.py
+++ b/src/fastapi_aad_auth/_base/backend.py
@@ -1,5 +1,5 @@
 """Base OAuthBackend with token and session validators."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from fastapi.security import OAuth2
 from starlette.authentication import AuthCredentials, AuthenticationBackend, UnauthenticatedUser

--- a/src/fastapi_aad_auth/_base/backend.py
+++ b/src/fastapi_aad_auth/_base/backend.py
@@ -59,7 +59,11 @@ class BaseOAuthBackend(NotAuthenticatedMixin, LoggingMixin, AuthenticationBacken
         for validator in self.validators:
             yield validator
 
-    def requires_auth(self, scopes: str = 'authenticated', allow_session: bool = False):
+    def requires_auth(self,
+                      scopes: str = 'authenticated',
+                      allow_session: bool = False,
+                      roles: Optional[Union[List[str], str]] = None,
+                      groups: Optional[Union[List[str], str]] = None):
         """Require authentication, use with fastapi Depends."""
         # This is a bit horrible, but is needed for fastapi to get this into OpenAPI (or similar) - it needs to be an OAuth2 object
         # We create this here "dynamically" for each endpoint, as we allow customisation on whether a session is permissible
@@ -80,7 +84,11 @@ class BaseOAuthBackend(NotAuthenticatedMixin, LoggingMixin, AuthenticationBacken
                     if state is None or not state.is_authenticated():
                         raise self.not_authenticated
                     elif not state.check_scopes(scopes):
-                        raise AuthorisationError(f'Not authorised for this API endpoint - Requires {scopes}')
+                        raise AuthorisationError(f'Not authorised for this API endpoint - Requires {scopes} scopes')
+                    elif not state.check_roles(roles):
+                        raise AuthorisationError(f'Not authorised for this API endpoint - Requires {roles} roles')
+                    elif not state.check_groups(groups):
+                        raise AuthorisationError(f'Not authorised for this API endpoint - Requires {groups} groups')
 
                     return state
 

--- a/src/fastapi_aad_auth/_base/state.py
+++ b/src/fastapi_aad_auth/_base/state.py
@@ -42,6 +42,14 @@ class User(InheritablePropertyBaseModel):
             for scope in self.scopes:
                 if not scope.startswith('.'):
                     permissions.append(scope)
+        if self.groups:
+            for group in self.groups:
+                if not group.startswith('.'):
+                    permissions.append(group)
+        if self.roles:
+            for role in self.roles:
+                if not role.startswith('.'):
+                    permissions.append(role)
         return permissions[:]
 
     @property

--- a/src/fastapi_aad_auth/_base/state.py
+++ b/src/fastapi_aad_auth/_base/state.py
@@ -26,6 +26,7 @@ class AuthenticationOptions(Enum):
 
 
 class InteractiveUser(SimpleUser):
+    """User for interactive components through Starlette."""
 
     def __init__(self,
                  username: str,
@@ -34,6 +35,7 @@ class InteractiveUser(SimpleUser):
                  roles: Optional[List[str]] = None,
                  groups: Optional[List[str]] = None,
                  scopes: Optional[List[str]] = None):
+        """Initialise the user."""
         super().__init__(username)
         self.name = name
         self.email = email

--- a/src/fastapi_aad_auth/_base/state.py
+++ b/src/fastapi_aad_auth/_base/state.py
@@ -54,7 +54,7 @@ class User(InheritablePropertyBaseModel):
     scopes: Optional[List[str]] = Field(None, description='Token scopes provided')
     interactive_klass: Type[BaseUser] = InteractiveUser
 
-    class Config:
+    class Config:  # noqa: D106
         json_encoders = {
             type: lambda a: f'{a.__module__}:{a.__name__}'
         }

--- a/src/fastapi_aad_auth/_base/state.py
+++ b/src/fastapi_aad_auth/_base/state.py
@@ -55,6 +55,18 @@ class User(InheritablePropertyBaseModel):
             value = value.split(' ')
         return value
 
+    @validator('roles', always=True, pre=True)
+    def _validate_roles(cls, value):
+        if isinstance(value, str):
+            value = value.split(' ')
+        return value
+
+    @validator('groups', always=True, pre=True)
+    def _validate_groups(cls, value):
+        if isinstance(value, str):
+            value = json.loads(value)
+        return value
+
 
 class AuthenticationState(LoggingMixin, InheritableBaseModel):
     """Authentication State."""
@@ -173,5 +185,27 @@ class AuthenticationState(LoggingMixin, InheritableBaseModel):
             required_scopes = required_scopes.split(' ')
         for scope in required_scopes:
             if scope in self.credentials.scopes:
+                return True
+        return False
+
+    def check_roles(self, required_roles: Optional[Union[List[str], str]] = None):
+        """Check if the user has the required roles."""
+        if required_roles is None:
+            return True
+        elif isinstance(required_roles, str):
+            required_roles = required_roles.split(' ')
+        for role in required_roles:
+            if self.user.roles and role in self.user.roles:
+                return True
+        return False
+
+    def check_groups(self, required_groups: Optional[Union[List[str], str]] = None):
+        """Check if the user has the required roles."""
+        if required_groups is None:
+            return True
+        elif isinstance(required_groups, str):
+            required_groups = required_groups.split(' ')
+        for role in required_groups:
+            if self.user.groups and role in self.user.groups:
                 return True
         return False

--- a/src/fastapi_aad_auth/_base/state.py
+++ b/src/fastapi_aad_auth/_base/state.py
@@ -203,7 +203,7 @@ class AuthenticationState(LoggingMixin, InheritableBaseModel):
         elif isinstance(required_roles, str):
             required_roles = required_roles.split(' ')
         for role in required_roles:
-            if self.user.roles and role in self.user.roles:
+            if self.user and self.user.roles and role in self.user.roles:
                 return True
         return False
 
@@ -213,7 +213,7 @@ class AuthenticationState(LoggingMixin, InheritableBaseModel):
             return True
         elif isinstance(required_groups, str):
             required_groups = required_groups.split(' ')
-        for role in required_groups:
-            if self.user.groups and role in self.user.groups:
+        for group in required_groups:
+            if self.user and self.user.groups and group in self.user.groups:
                 return True
         return False

--- a/src/fastapi_aad_auth/auth.py
+++ b/src/fastapi_aad_auth/auth.py
@@ -170,7 +170,11 @@ class Authenticator(LoggingMixin):
 
         return wrapper
 
-    def api_auth_required(self, scopes: str = 'authenticated', allow_session: bool = True):
+    def api_auth_required(self,
+                          scopes: str = 'authenticated',
+                          allow_session: bool = True,
+                          roles: Optional[Union[List['str'], 'str']] = None,
+                          groups: Optional[Union[List['str'], 'str']] = None):
         """Decorator to require specific scopes (and redirect to the login ui) for an endpoint.
 
         This can be used for enabling authentication on an API endpoint, using the fastapi
@@ -186,7 +190,7 @@ class Authenticator(LoggingMixin):
             if self.config.enabled:
 
                 # Create the oauth endpoint
-                oauth = self.auth_backend.requires_auth(scopes=scopes, allow_session=allow_session)
+                oauth = self.auth_backend.requires_auth(scopes=scopes, allow_session=allow_session, roles=roles, groups=groups)
 
                 # We need to do some signature hackery for fastapi
                 endpoint_signature = inspect.signature(endpoint)

--- a/src/fastapi_aad_auth/providers/aad.py
+++ b/src/fastapi_aad_auth/providers/aad.py
@@ -323,7 +323,7 @@ class AADProvider(Provider):
             token_scopes = {}
         token_validator = AADTokenValidator(client_id=client_id, tenant_id=tenant_id, api_audience=api_audience,
                                             client_app_ids=client_app_ids, scopes=token_scopes, enabled=enabled, strict=strict_token,
-                                            user_klass=user_klass, flow_type=flow_type, roles=roles, jwks_cache_ttl=jwks_cache_ttl) 
+                                            user_klass=user_klass, flow_type=flow_type, roles=roles, jwks_cache_ttl=jwks_cache_ttl)
         session_authenticator = AADSessionAuthenticator(session_validator=session_validator, token_validator=token_validator,
                                                         client_id=client_id, tenant_id=tenant_id, redirect_path=redirect_path,
                                                         prompt=prompt, client_secret=client_secret, scopes=scopes,


### PR DESCRIPTION
This should implement fixes for #74:
* Can use ``AAD_ROLES`` to set required roles on all endpoints
* ``requires_auth`` has roles (and groups) parameters
* ``api_auth_required`` has roles (and groups) parameters
* ``request.auth.credentials`` now includes roles and groups
* ``InteractiveUser`` object for ``request.user`` includes additional parameters (roles, groups, scopes) for processing 

Closes #74 