### PR TITLE
Add 'packaging' package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 pydantic[dotenv]
 itsdangerous
 cachetools
+packaging


### PR DESCRIPTION
fastapi_aad_auth imports the `packaging` library, but it isn't listed in the `requirements.txt`. This PR fixes that.

(I've found in the past that various other packages pull in the `packaging` library, and it can often seem like it is part of the standard library, but it actually isn't, so needs to be included as a requirement)